### PR TITLE
Add reading task tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An extension for Zotero that allows setting the read status of items.
 - custom read statuses are also supported
 - newly added items can be automatically labelled
 - an item's read status can be automatically updated when opening its attached PDF
+- record per-item reading tasks (modules, units, chapters, pages) and view progress
 
 ![windows dark theme overview](https://github.com/Dominic-DallOsto/zotero-reading-list/assets/26859884/e35ef424-02cd-4bec-8866-3e1d30c9aadf)
 

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -14,3 +14,6 @@ invalid-status-names-title = Custom Reading Statuses Contains Invalid Characters
 invalid-status-names-description = Custom reading statuses and icons cannot contain the characters : ; or |. Please remove these characters.
 
 autolabelnewitems-disabled = Disabled
+reading-tasks-menu = Show Reading Tasks
+reading-tasks-title = Reading Tasks
+reading-tasks-none = No reading tasks recorded

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -15,6 +15,7 @@ import {
 	clearItemExtraProperty,
 	removeFieldValueFromExtraData,
 } from "../utils/extraField";
+import { getReadingTasks, tasksToString } from "./reading-tasks";
 
 const READ_STATUS_COLUMN_ID = "readstatus";
 const READ_STATUS_EXTRA_FIELD = "Read_Status";
@@ -90,6 +91,25 @@ function clearSelectedItemsReadStatus() {
  */
 function getSelectedItems() {
 	return ZoteroPane.getSelectedItems().filter((item) => item.isRegularItem());
+}
+
+function showReadingTasks() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	const lines: string[] = [];
+	for (const item of items) {
+		const tasks = getReadingTasks(item);
+		if (tasks.length) {
+			lines.push(item.getField("title"));
+			lines.push(tasksToString(tasks));
+		}
+	}
+	const message = lines.length
+		? lines.join("\n")
+		: getString("reading-tasks-none");
+	Services.prompt.alert(null, getString("reading-tasks-title"), message);
 }
 
 export const FORBIDDEN_PREF_STRING_CHARACTERS = new Set(":;|");
@@ -388,19 +408,22 @@ export default class ZoteroReadingList {
 				{
 					tag: "menuitem",
 					label: getString("status-none"),
-					commandListener: (event) =>
-						void clearSelectedItemsReadStatus(),
+					commandListener: () => void clearSelectedItemsReadStatus(),
 				} as MenuitemOptions,
-			].concat(
-				this.statusNames.map((status_name: string) => {
+				...this.statusNames.map((status_name: string) => {
 					return {
 						tag: "menuitem",
 						label: this.formatStatusName(status_name),
-						commandListener: (event) =>
+						commandListener: () =>
 							setSelectedItemsReadStatus(status_name),
 					};
 				}),
-			),
+				{
+					tag: "menuitem",
+					label: getString("reading-tasks-menu"),
+					commandListener: () => showReadingTasks(),
+				},
+			],
 			getVisibility: (element, event) => {
 				return getSelectedItems().length > 0;
 			},

--- a/src/modules/reading-tasks.ts
+++ b/src/modules/reading-tasks.ts
@@ -1,0 +1,56 @@
+export interface ReadingTask {
+	module: string;
+	unit: string;
+	chapter?: string;
+	pages?: string;
+	paragraph?: string;
+	done?: boolean;
+}
+
+const READING_TASKS_EXTRA_FIELD = "Reading_Tasks";
+
+import {
+	getItemExtraProperty,
+	setItemExtraProperty,
+} from "../utils/extraField";
+
+export function getReadingTasks(item: Zotero.Item): ReadingTask[] {
+	const extra = getItemExtraProperty(item, READING_TASKS_EXTRA_FIELD);
+	if (extra.length) {
+		try {
+			return JSON.parse(extra[0]) as ReadingTask[];
+		} catch {
+			return [];
+		}
+	}
+	return [];
+}
+
+export function setReadingTasks(item: Zotero.Item, tasks: ReadingTask[]): void {
+	setItemExtraProperty(
+		item,
+		READING_TASKS_EXTRA_FIELD,
+		JSON.stringify(tasks),
+	);
+	void item.saveTx();
+}
+
+export function markTaskAsDone(item: Zotero.Item, index: number): void {
+	const tasks = getReadingTasks(item);
+	if (tasks[index]) {
+		tasks[index].done = true;
+		setReadingTasks(item, tasks);
+	}
+}
+
+export function tasksToString(tasks: ReadingTask[]): string {
+	return tasks
+		.map((t, idx) => {
+			const details = [t.module, t.unit, t.chapter, t.pages, t.paragraph]
+				.filter(Boolean)
+				.join(" > ");
+			const status = t.done ? "✔" : "✘";
+			return `${idx + 1}. ${details} - ${status}`;
+		})
+		.join("\n");
+}


### PR DESCRIPTION
## Summary
- support tracking reading tasks for items
- show tasks via new context menu option
- add localization strings for the new option
- document reading task feature in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68497cac15d08332b54c343b96dcee74