### PR TITLE
Add reading task tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An extension for Zotero that allows setting the read status of items.
 - custom read statuses are also supported
 - newly added items can be automatically labelled
 - an item's read status can be automatically updated when opening its attached PDF
+- record per-item reading tasks (modules, units, chapters, pages), mark them done, and view progress
 
 ![windows dark theme overview](https://github.com/Dominic-DallOsto/zotero-reading-list/assets/26859884/e35ef424-02cd-4bec-8866-3e1d30c9aadf)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extension for Zotero that allows setting the read status of items.
 - custom read statuses are also supported
 - newly added items can be automatically labelled
 - an item's read status can be automatically updated when opening its attached PDF
-- record per-item reading tasks (modules, units, chapters, pages), mark them done, and view progress
+- record per-item reading tasks for modules and units with pages, chapters, or paragraphs; mark them done, remove them, and view progress
 
 ![windows dark theme overview](https://github.com/Dominic-DallOsto/zotero-reading-list/assets/26859884/e35ef424-02cd-4bec-8866-3e1d30c9aadf)
 

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -14,3 +14,12 @@ invalid-status-names-title = Custom Reading Statuses Contains Invalid Characters
 invalid-status-names-description = Custom reading statuses and icons cannot contain the characters : ; or |. Please remove these characters.
 
 autolabelnewitems-disabled = Disabled
+reading-tasks-menu = Show Reading Tasks
+reading-tasks-title = Reading Tasks
+reading-tasks-none = No reading tasks recorded
+add-reading-task-menu = Add Reading Task
+reading-task-prompt-module = Module
+reading-task-prompt-unit = Unit
+reading-task-prompt-chapter = Chapter
+reading-task-prompt-pages = Pages
+reading-task-prompt-paragraph = Paragraph

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -23,3 +23,7 @@ reading-task-prompt-unit = Unit
 reading-task-prompt-chapter = Chapter
 reading-task-prompt-pages = Pages
 reading-task-prompt-paragraph = Paragraph
+toggle-reading-task-menu = Toggle Reading Task Done
+remove-reading-task-menu = Remove Reading Task
+reading-task-prompt-index = Task number
+reading-task-prompt-type = Task Type

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -15,6 +15,11 @@ import {
 	clearItemExtraProperty,
 	removeFieldValueFromExtraData,
 } from "../utils/extraField";
+import {
+	addReadingTask,
+	getReadingTasks,
+	tasksToString,
+} from "./reading-tasks";
 
 const READ_STATUS_COLUMN_ID = "readstatus";
 const READ_STATUS_EXTRA_FIELD = "Read_Status";
@@ -90,6 +95,108 @@ function clearSelectedItemsReadStatus() {
  */
 function getSelectedItems() {
 	return ZoteroPane.getSelectedItems().filter((item) => item.isRegularItem());
+}
+
+function showReadingTasks() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	const lines: string[] = [];
+	for (const item of items) {
+		const tasks = getReadingTasks(item);
+		if (tasks.length) {
+			lines.push(item.getField("title"));
+			lines.push(tasksToString(tasks));
+		}
+	}
+	const message = lines.length
+		? lines.join("\n")
+		: getString("reading-tasks-none");
+	Services.prompt.alert(
+		window as mozIDOMWindowProxy,
+		getString("reading-tasks-title"),
+		message,
+	);
+}
+
+function promptAddReadingTask() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	const promptSvc: { prompt(...args: any[]): boolean } =
+		Services.prompt as unknown as { prompt(...args: any[]): boolean };
+	const moduleInput = { value: "" };
+
+	if (
+		!promptSvc.prompt(
+			window as mozIDOMWindowProxy,
+			getString("add-reading-task-menu"),
+			getString("reading-task-prompt-module"),
+			moduleInput,
+			null,
+			{},
+		)
+	) {
+		return;
+	}
+	const unitInput = { value: "" };
+
+	if (
+		!promptSvc.prompt(
+			window as mozIDOMWindowProxy,
+			getString("add-reading-task-menu"),
+			getString("reading-task-prompt-unit"),
+			unitInput,
+			null,
+			{},
+		)
+	) {
+		return;
+	}
+	const chapterInput = { value: "" };
+
+	promptSvc.prompt(
+		window as mozIDOMWindowProxy,
+		getString("add-reading-task-menu"),
+		getString("reading-task-prompt-chapter"),
+		chapterInput,
+		null,
+		{},
+	);
+	const pagesInput = { value: "" };
+
+	promptSvc.prompt(
+		window as mozIDOMWindowProxy,
+		getString("add-reading-task-menu"),
+		getString("reading-task-prompt-pages"),
+		pagesInput,
+		null,
+		{},
+	);
+	const paragraphInput = { value: "" };
+
+	promptSvc.prompt(
+		window as mozIDOMWindowProxy,
+		getString("add-reading-task-menu"),
+		getString("reading-task-prompt-paragraph"),
+		paragraphInput,
+		null,
+		{},
+	);
+
+	const task = {
+		module: moduleInput.value.trim(),
+		unit: unitInput.value.trim(),
+		chapter: chapterInput.value.trim() || undefined,
+		pages: pagesInput.value.trim() || undefined,
+		paragraph: paragraphInput.value.trim() || undefined,
+	} as import("./reading-tasks").ReadingTask;
+
+	for (const item of items) {
+		addReadingTask(item, task);
+	}
 }
 
 export const FORBIDDEN_PREF_STRING_CHARACTERS = new Set(":;|");
@@ -386,21 +493,29 @@ export default class ZoteroReadingList {
 			label: getString("menupopup-label"),
 			children: [
 				{
-					tag: "menuitem",
+					tag: "menuitem" as const,
 					label: getString("status-none"),
-					commandListener: (event) =>
-						void clearSelectedItemsReadStatus(),
+					commandListener: () => void clearSelectedItemsReadStatus(),
 				} as MenuitemOptions,
-			].concat(
-				this.statusNames.map((status_name: string) => {
-					return {
-						tag: "menuitem",
+				...this.statusNames.map(
+					(status_name: string): MenuitemOptions => ({
+						tag: "menuitem" as const,
 						label: this.formatStatusName(status_name),
-						commandListener: (event) =>
+						commandListener: () =>
 							setSelectedItemsReadStatus(status_name),
-					};
-				}),
-			),
+					}),
+				),
+				{
+					tag: "menuitem" as const,
+					label: getString("reading-tasks-menu"),
+					commandListener: () => showReadingTasks(),
+				} as MenuitemOptions,
+				{
+					tag: "menuitem" as const,
+					label: getString("add-reading-task-menu"),
+					commandListener: () => promptAddReadingTask(),
+				} as MenuitemOptions,
+			] as MenuitemOptions[],
 			getVisibility: (element, event) => {
 				return getSelectedItems().length > 0;
 			},

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -19,6 +19,8 @@ import {
 	addReadingTask,
 	getReadingTasks,
 	tasksToString,
+	toggleTaskDone,
+	removeReadingTask,
 } from "./reading-tasks";
 
 const READ_STATUS_COLUMN_ID = "readstatus";
@@ -125,21 +127,50 @@ function promptAddReadingTask() {
 	if (!items.length) {
 		return;
 	}
-	const promptSvc: { prompt(...args: any[]): boolean } =
-		Services.prompt as unknown as { prompt(...args: any[]): boolean };
-	const moduleInput = { value: "" };
+	const promptSvc: {
+		prompt(...args: any[]): boolean;
+		select(...args: any[]): boolean;
+	} = Services.prompt as unknown as {
+		prompt(...args: any[]): boolean;
+		select(...args: any[]): boolean;
+	};
 
-	if (
-		!promptSvc.prompt(
-			window as mozIDOMWindowProxy,
-			getString("add-reading-task-menu"),
-			getString("reading-task-prompt-module"),
-			moduleInput,
-			null,
-			{},
-		)
-	) {
-		return;
+	let moduleName = "";
+	const rootCollections = Zotero.Collections.getByLibrary(
+		Zotero.Libraries.userLibraryID,
+		false,
+	);
+	if (rootCollections.length) {
+		const names = rootCollections.map((c) => c.name);
+		const idx = { value: 0 };
+		if (
+			!promptSvc.select(
+				window as mozIDOMWindowProxy,
+				getString("add-reading-task-menu"),
+				getString("reading-task-prompt-module"),
+				names.length,
+				names,
+				idx,
+			)
+		) {
+			return;
+		}
+		moduleName = names[idx.value];
+	} else {
+		const moduleInput = { value: "" };
+		if (
+			!promptSvc.prompt(
+				window as mozIDOMWindowProxy,
+				getString("add-reading-task-menu"),
+				getString("reading-task-prompt-module"),
+				moduleInput,
+				null,
+				{},
+			)
+		) {
+			return;
+		}
+		moduleName = moduleInput.value.trim();
 	}
 	const unitInput = { value: "" };
 
@@ -155,47 +186,105 @@ function promptAddReadingTask() {
 	) {
 		return;
 	}
-	const chapterInput = { value: "" };
-
-	promptSvc.prompt(
-		window as mozIDOMWindowProxy,
-		getString("add-reading-task-menu"),
-		getString("reading-task-prompt-chapter"),
-		chapterInput,
-		null,
-		{},
-	);
-	const pagesInput = { value: "" };
-
-	promptSvc.prompt(
-		window as mozIDOMWindowProxy,
-		getString("add-reading-task-menu"),
-		getString("reading-task-prompt-pages"),
-		pagesInput,
-		null,
-		{},
-	);
-	const paragraphInput = { value: "" };
-
-	promptSvc.prompt(
-		window as mozIDOMWindowProxy,
-		getString("add-reading-task-menu"),
-		getString("reading-task-prompt-paragraph"),
-		paragraphInput,
-		null,
-		{},
-	);
+	const types = ["Chapter", "Pages", "Paragraph"];
+	const typeIdx = { value: 0 };
+	if (
+		!promptSvc.select(
+			window as mozIDOMWindowProxy,
+			getString("add-reading-task-menu"),
+			getString("reading-task-prompt-type"),
+			types.length,
+			types,
+			typeIdx,
+		)
+	) {
+		return;
+	}
+	const typeKey = types[typeIdx.value].toLowerCase() as
+		| "chapter"
+		| "pages"
+		| "paragraph";
+	const valueInput = { value: "" };
+	if (
+		!promptSvc.prompt(
+			window as mozIDOMWindowProxy,
+			getString("add-reading-task-menu"),
+			getString(`reading-task-prompt-${typeKey}`),
+			valueInput,
+			null,
+			{},
+		)
+	) {
+		return;
+	}
 
 	const task = {
-		module: moduleInput.value.trim(),
+		module: moduleName,
 		unit: unitInput.value.trim(),
-		chapter: chapterInput.value.trim() || undefined,
-		pages: pagesInput.value.trim() || undefined,
-		paragraph: paragraphInput.value.trim() || undefined,
+		type: typeKey,
+		value: valueInput.value.trim(),
 	} as import("./reading-tasks").ReadingTask;
 
 	for (const item of items) {
 		addReadingTask(item, task);
+	}
+}
+
+function promptToggleReadingTaskDone() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	const promptSvc: { prompt(...args: any[]): boolean } =
+		Services.prompt as unknown as { prompt(...args: any[]): boolean };
+	const indexInput = { value: "" };
+	if (
+		!promptSvc.prompt(
+			window as mozIDOMWindowProxy,
+			getString("toggle-reading-task-menu"),
+			getString("reading-task-prompt-index"),
+			indexInput,
+			null,
+			{},
+		)
+	) {
+		return;
+	}
+	const idx = parseInt(indexInput.value) - 1;
+	if (isNaN(idx)) {
+		return;
+	}
+	for (const item of items) {
+		toggleTaskDone(item, idx);
+	}
+}
+
+function promptRemoveReadingTask() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	const promptSvc: { prompt(...args: any[]): boolean } =
+		Services.prompt as unknown as { prompt(...args: any[]): boolean };
+	const indexInput = { value: "" };
+	if (
+		!promptSvc.prompt(
+			window as mozIDOMWindowProxy,
+			getString("remove-reading-task-menu"),
+			getString("reading-task-prompt-index"),
+			indexInput,
+			null,
+			{},
+		)
+	) {
+		return;
+	}
+	const idx = parseInt(indexInput.value) - 1;
+	if (isNaN(idx)) {
+		return;
+	}
+	for (const item of items) {
+		removeReadingTask(item, idx);
 	}
 }
 
@@ -514,6 +603,16 @@ export default class ZoteroReadingList {
 					tag: "menuitem" as const,
 					label: getString("add-reading-task-menu"),
 					commandListener: () => promptAddReadingTask(),
+				} as MenuitemOptions,
+				{
+					tag: "menuitem" as const,
+					label: getString("toggle-reading-task-menu"),
+					commandListener: () => promptToggleReadingTaskDone(),
+				} as MenuitemOptions,
+				{
+					tag: "menuitem" as const,
+					label: getString("remove-reading-task-menu"),
+					commandListener: () => promptRemoveReadingTask(),
 				} as MenuitemOptions,
 			] as MenuitemOptions[],
 			getVisibility: (element, event) => {

--- a/src/modules/reading-tasks.ts
+++ b/src/modules/reading-tasks.ts
@@ -1,9 +1,8 @@
 export interface ReadingTask {
 	module: string;
 	unit: string;
-	chapter?: string;
-	pages?: string;
-	paragraph?: string;
+	type: "chapter" | "pages" | "paragraph";
+	value: string;
 	done?: boolean;
 }
 
@@ -41,10 +40,18 @@ export function addReadingTask(item: Zotero.Item, task: ReadingTask): void {
 	setReadingTasks(item, tasks);
 }
 
-export function markTaskAsDone(item: Zotero.Item, index: number): void {
+export function toggleTaskDone(item: Zotero.Item, index: number): void {
 	const tasks = getReadingTasks(item);
 	if (tasks[index]) {
-		tasks[index].done = true;
+		tasks[index].done = !tasks[index].done;
+		setReadingTasks(item, tasks);
+	}
+}
+
+export function removeReadingTask(item: Zotero.Item, index: number): void {
+	const tasks = getReadingTasks(item);
+	if (tasks[index]) {
+		tasks.splice(index, 1);
 		setReadingTasks(item, tasks);
 	}
 }
@@ -52,7 +59,8 @@ export function markTaskAsDone(item: Zotero.Item, index: number): void {
 export function tasksToString(tasks: ReadingTask[]): string {
 	return tasks
 		.map((t, idx) => {
-			const details = [t.module, t.unit, t.chapter, t.pages, t.paragraph]
+			const valueLabel = t.type.charAt(0).toUpperCase() + t.type.slice(1);
+			const details = [t.module, t.unit, `${valueLabel}: ${t.value}`]
 				.filter(Boolean)
 				.join(" > ");
 			const status = t.done ? "✔" : "✘";

--- a/src/modules/reading-tasks.ts
+++ b/src/modules/reading-tasks.ts
@@ -1,0 +1,62 @@
+export interface ReadingTask {
+	module: string;
+	unit: string;
+	chapter?: string;
+	pages?: string;
+	paragraph?: string;
+	done?: boolean;
+}
+
+const READING_TASKS_EXTRA_FIELD = "Reading_Tasks";
+
+import {
+	getItemExtraProperty,
+	setItemExtraProperty,
+} from "../utils/extraField";
+
+export function getReadingTasks(item: Zotero.Item): ReadingTask[] {
+	const extra = getItemExtraProperty(item, READING_TASKS_EXTRA_FIELD);
+	if (extra.length) {
+		try {
+			return JSON.parse(extra[0]) as ReadingTask[];
+		} catch {
+			return [];
+		}
+	}
+	return [];
+}
+
+export function setReadingTasks(item: Zotero.Item, tasks: ReadingTask[]): void {
+	setItemExtraProperty(
+		item,
+		READING_TASKS_EXTRA_FIELD,
+		JSON.stringify(tasks),
+	);
+	void item.saveTx();
+}
+
+export function addReadingTask(item: Zotero.Item, task: ReadingTask): void {
+	const tasks = getReadingTasks(item);
+	tasks.push(task);
+	setReadingTasks(item, tasks);
+}
+
+export function markTaskAsDone(item: Zotero.Item, index: number): void {
+	const tasks = getReadingTasks(item);
+	if (tasks[index]) {
+		tasks[index].done = true;
+		setReadingTasks(item, tasks);
+	}
+}
+
+export function tasksToString(tasks: ReadingTask[]): string {
+	return tasks
+		.map((t, idx) => {
+			const details = [t.module, t.unit, t.chapter, t.pages, t.paragraph]
+				.filter(Boolean)
+				.join(" > ");
+			const status = t.done ? "✔" : "✘";
+			return `${idx + 1}. ${details} - ${status}`;
+		})
+		.join("\n");
+}


### PR DESCRIPTION
## Summary
- support tracking reading tasks for items
- show tasks via new context menu option
- add localization strings for the new option
- document reading task feature in README
- allow creating new reading tasks via prompt dialogs
- fix overlay prompts and menu type declarations

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68497cac15d08332b54c343b96dcee74