### PR TITLE
Store reading tasks in hidden note

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -31,3 +31,7 @@ reading-tasks-pane-header = Reading Tasks
 reading-tasks-pane-sidenav = Reading Tasks
 reading-tasks-dashboard-title = Reading Tasks Dashboard
 filter-placeholder = Filter…
+import-reading-tasks-menu = Import Reading Tasks
+import-reading-tasks-title = Import Reading Tasks
+import-reading-tasks-parse = Parse
+import-reading-tasks-import = Import

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -29,3 +29,5 @@ reading-task-type-additional = Additional
 manage-reading-tasks-menu = Manage Reading Tasks
 reading-tasks-pane-header = Reading Tasks
 reading-tasks-pane-sidenav = Reading Tasks
+reading-tasks-dashboard-title = Reading Tasks Dashboard
+filter-placeholder = Filter…

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -2,6 +2,7 @@ import { ColumnOptions, DialogHelper } from "zotero-plugin-toolkit";
 import hooks from "./hooks";
 import prefsMenu from "./prefs-menu";
 import readingTasksView from "./reading-tasks-view";
+import readingTasksDashboard from "./reading-tasks-dashboard";
 import { createZToolkit } from "./utils/ztoolkit";
 
 class Addon {
@@ -24,6 +25,7 @@ class Addon {
 	public hooks: typeof hooks;
 	public prefsMenu: typeof prefsMenu;
 	public readingTasksView: typeof readingTasksView;
+	public readingTasksDashboard: typeof readingTasksDashboard;
 	// APIs
 	public api: object;
 
@@ -36,6 +38,7 @@ class Addon {
 		this.hooks = hooks;
 		this.prefsMenu = prefsMenu;
 		this.readingTasksView = readingTasksView;
+		this.readingTasksDashboard = readingTasksDashboard;
 		this.api = {};
 	}
 }

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -3,6 +3,7 @@ import hooks from "./hooks";
 import prefsMenu from "./prefs-menu";
 import readingTasksView from "./reading-tasks-view";
 import readingTasksDashboard from "./reading-tasks-dashboard";
+import readingTasksImport from "./reading-tasks-import";
 import { createZToolkit } from "./utils/ztoolkit";
 
 class Addon {
@@ -26,6 +27,7 @@ class Addon {
 	public prefsMenu: typeof prefsMenu;
 	public readingTasksView: typeof readingTasksView;
 	public readingTasksDashboard: typeof readingTasksDashboard;
+	public readingTasksImport: typeof readingTasksImport;
 	// APIs
 	public api: object;
 
@@ -39,6 +41,7 @@ class Addon {
 		this.prefsMenu = prefsMenu;
 		this.readingTasksView = readingTasksView;
 		this.readingTasksDashboard = readingTasksDashboard;
+		this.readingTasksImport = readingTasksImport;
 		this.api = {};
 	}
 }

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -575,6 +575,11 @@ export default class ZoteroReadingList {
 					commandListener: () =>
 						void addon.readingTasksDashboard.open(),
 				} as MenuitemOptions,
+				{
+					tag: "menuitem" as const,
+					label: getString("import-reading-tasks-menu"),
+					commandListener: () => void addon.readingTasksImport.open(),
+				} as MenuitemOptions,
 			] as MenuitemOptions[],
 			getVisibility: (element, event) => {
 				return getSelectedItems().length > 0;

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -612,7 +612,7 @@ export default class ZoteroReadingList {
 				icon: `chrome://${config.addonRef}/content/icons/favicon.png`,
 			},
 			bodyXHTML:
-				'<div xmlns="http://www.w3.org/1999/xhtml"><div id="reading-tasks-pane-body" style="white-space: pre-wrap;"></div><div style="margin-top:4px;"><button id="reading-tasks-pane-add"></button><button id="reading-tasks-pane-manage" style="margin-left:4px;"></button></div></div>',
+				'<div xmlns="http://www.w3.org/1999/xhtml"><div id="reading-tasks-pane-body" style="white-space: pre-wrap;"></div><div style="margin-top:4px;"><button id="reading-tasks-pane-add"></button><button id="reading-tasks-pane-manage" style="margin-left:4px;"></button><button id="reading-tasks-pane-dashboard" style="margin-left:4px;"></button><button id="reading-tasks-pane-import" style="margin-left:4px;"></button></div></div>',
 			onRender: ({
 				body,
 				item,
@@ -643,6 +643,28 @@ export default class ZoteroReadingList {
 						"manage-reading-tasks-menu",
 					);
 					manageBtn.onclick = () => addon.readingTasksView.open(item); // ← one handler only
+				}
+
+				const dashBtn = body.querySelector<HTMLButtonElement>(
+					"#reading-tasks-pane-dashboard",
+				);
+				if (dashBtn) {
+					dashBtn.textContent = getString(
+						"reading-tasks-dashboard-title",
+					);
+					dashBtn.onclick = () =>
+						void addon.readingTasksDashboard.open();
+				}
+
+				const importBtn = body.querySelector<HTMLButtonElement>(
+					"#reading-tasks-pane-import",
+				);
+				if (importBtn) {
+					importBtn.textContent = getString(
+						"import-reading-tasks-menu",
+					);
+					importBtn.onclick = () =>
+						void addon.readingTasksImport.open(item);
 				}
 			},
 		});

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -149,6 +149,14 @@ function openManageReadingTasks() {
 	void addon.readingTasksView.open(items[0]);
 }
 
+function openImportReadingTasks() {
+	const items = getSelectedItems();
+	if (!items.length) {
+		return;
+	}
+	void addon.readingTasksImport.open(items[0]);
+}
+
 function promptAddReadingTask() {
 	const items = getSelectedItems();
 	if (!items.length) {
@@ -578,7 +586,7 @@ export default class ZoteroReadingList {
 				{
 					tag: "menuitem" as const,
 					label: getString("import-reading-tasks-menu"),
-					commandListener: () => void addon.readingTasksImport.open(),
+					commandListener: () => openImportReadingTasks(),
 				} as MenuitemOptions,
 			] as MenuitemOptions[],
 			getVisibility: (element, event) => {

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -569,6 +569,12 @@ export default class ZoteroReadingList {
 					label: getString("manage-reading-tasks-menu"),
 					commandListener: () => openManageReadingTasks(),
 				} as MenuitemOptions,
+				{
+					tag: "menuitem" as const,
+					label: getString("reading-tasks-dashboard-title"),
+					commandListener: () =>
+						void addon.readingTasksDashboard.open(),
+				} as MenuitemOptions,
 			] as MenuitemOptions[],
 			getVisibility: (element, event) => {
 				return getSelectedItems().length > 0;
@@ -602,24 +608,28 @@ export default class ZoteroReadingList {
 				item: Zotero.Item;
 			}) => {
 				const tasks = getReadingTasks(item);
-				const textDiv = body.querySelector(
-					"#reading-tasks-pane-body",
-				) as HTMLDivElement | null;
+				const textDiv = body.querySelector("#reading-tasks-pane-body");
 				if (textDiv) {
 					textDiv.textContent = tasks.length
 						? tasksToString(tasks)
 						: getString("reading-tasks-none");
 				}
-				const addBtn = body.querySelector("#reading-tasks-pane-add") as HTMLButtonElement | null;
+				const addBtn = body.querySelector<HTMLButtonElement>(
+					"#reading-tasks-pane-add",
+				);
 				if (addBtn) {
 					addBtn.textContent = getString("add-reading-task-menu");
-					addBtn.onclick = () => promptAddReadingTask();           // ← one handler only
+					addBtn.onclick = () => promptAddReadingTask(); // ← one handler only
 				}
 
-				const manageBtn = body.querySelector("#reading-tasks-pane-manage") as HTMLButtonElement | null;
+				const manageBtn = body.querySelector<HTMLButtonElement>(
+					"#reading-tasks-pane-manage",
+				);
 				if (manageBtn) {
-					manageBtn.textContent = getString("manage-reading-tasks-menu");
-					manageBtn.onclick = () => addon.readingTasksView.open(item);   // ← one handler only
+					manageBtn.textContent = getString(
+						"manage-reading-tasks-menu",
+					);
+					manageBtn.onclick = () => addon.readingTasksView.open(item); // ← one handler only
 				}
 			},
 		});

--- a/src/modules/reading-tasks.ts
+++ b/src/modules/reading-tasks.ts
@@ -79,19 +79,33 @@ export function updateItemTagsFromTasks(item: Zotero.Item): void {
 			moduleTags.add(t.module);
 		}
 		if (t.type) {
-			typeTags.add(t.type);
+			// Convert required/additional types into longer tag names
+			if (/^Required$/i.test(t.type)) {
+				typeTags.add("Required Reading");
+			} else if (/^Additional$/i.test(t.type)) {
+				typeTags.add("Additional Reading");
+			} else {
+				typeTags.add(t.type);
+			}
 		}
 	}
+
 	const existing = item.getTags().map((t) => t.tag);
 	for (const tag of existing) {
 		if (/^Unit\s/.test(tag) && !unitTags.has(tag)) {
 			item.removeTag(tag);
 		} else if (/ULAW/.test(tag) && !moduleTags.has(tag)) {
 			item.removeTag(tag);
-		} else if (/^(Required|Additional)$/i.test(tag) && !typeTags.has(tag)) {
+		} else if (
+			/^(Required Reading|Additional Reading|Required|Additional)$/i.test(
+				tag,
+			) &&
+			!typeTags.has(tag)
+		) {
 			item.removeTag(tag);
 		}
 	}
+
 	for (const tag of unitTags) {
 		if (!existing.includes(tag)) {
 			item.addTag(tag);
@@ -107,5 +121,6 @@ export function updateItemTagsFromTasks(item: Zotero.Item): void {
 			item.addTag(tag);
 		}
 	}
+
 	void item.saveTx();
 }

--- a/src/modules/reading-tasks.ts
+++ b/src/modules/reading-tasks.ts
@@ -8,18 +8,13 @@ export interface ReadingTask {
 	status: string;
 }
 
-const READING_TASKS_EXTRA_FIELD = "Reading_Tasks";
-
-import {
-	getItemExtraProperty,
-	setItemExtraProperty,
-} from "../utils/extraField";
+import { getTasksFromNote, saveTasksToNote } from "../utils/noteHelpers";
 
 export function getReadingTasks(item: Zotero.Item): ReadingTask[] {
-	const extra = getItemExtraProperty(item, READING_TASKS_EXTRA_FIELD);
-	if (extra.length) {
+	const content = getTasksFromNote(item);
+	if (content) {
 		try {
-			return JSON.parse(extra[0]) as ReadingTask[];
+			return JSON.parse(content) as ReadingTask[];
 		} catch {
 			return [];
 		}
@@ -28,12 +23,7 @@ export function getReadingTasks(item: Zotero.Item): ReadingTask[] {
 }
 
 export function setReadingTasks(item: Zotero.Item, tasks: ReadingTask[]): void {
-	setItemExtraProperty(
-		item,
-		READING_TASKS_EXTRA_FIELD,
-		JSON.stringify(tasks),
-	);
-	void item.saveTx();
+	saveTasksToNote(item, JSON.stringify(tasks));
 	updateItemTagsFromTasks(item);
 }
 

--- a/src/reading-tasks-dashboard.ts
+++ b/src/reading-tasks-dashboard.ts
@@ -1,6 +1,7 @@
 import { DialogHelper } from "zotero-plugin-toolkit";
 import { getString } from "./utils/locale";
 import { getReadingTasks, ReadingTask } from "./modules/reading-tasks";
+import { getTitleFromNote } from "./utils/noteHelpers";
 
 interface ItemTask {
 	item: Zotero.Item;
@@ -34,7 +35,7 @@ async function getAllItemTasks(): Promise<ItemTask[]> {
 function createRow(doc: Document, it: ItemTask) {
 	const row = doc.createElement("tr");
 	const cells = [
-		it.item.getField("title"),
+		it.item.getField("title") || getTitleFromNote(it.item) || "",
 		it.task.module,
 		it.task.unit,
 		it.task.chapter || "",
@@ -184,15 +185,17 @@ function applyFilterAndSort(doc: Document) {
 	tbody.replaceChildren();
 	let tasks = currentTasks;
 	if (filter) {
-		tasks = tasks.filter((it) =>
-			`${it.item.getField("title")} ${it.task.module} ${it.task.unit} ${
+		tasks = tasks.filter((it) => {
+			const title =
+				it.item.getField("title") || getTitleFromNote(it.item) || "";
+			return `${title} ${it.task.module} ${it.task.unit} ${
 				it.task.chapter || ""
 			} ${it.task.pages || ""} ${it.task.paragraph || ""} ${
 				it.task.type || ""
 			} ${it.task.status}`
 				.toLowerCase()
-				.includes(filter),
-		);
+				.includes(filter);
+		});
 	}
 	tasks = tasks.slice().sort((a, b) => {
 		const va = getValue(a, sortKey);
@@ -208,7 +211,7 @@ function applyFilterAndSort(doc: Document) {
 
 function getValue(it: ItemTask, key: keyof ItemTask["task"] | "title") {
 	if (key === "title") {
-		return it.item.getField("title");
+		return it.item.getField("title") || getTitleFromNote(it.item) || "";
 	}
 	return it.task[key] || "";
 }

--- a/src/reading-tasks-dashboard.ts
+++ b/src/reading-tasks-dashboard.ts
@@ -1,0 +1,210 @@
+import { DialogHelper } from "zotero-plugin-toolkit";
+import { getString } from "./utils/locale";
+import { getReadingTasks, ReadingTask } from "./modules/reading-tasks";
+
+interface ItemTask {
+	item: Zotero.Item;
+	task: ReadingTask;
+}
+
+const BODY_ID = "reading-tasks-dashboard-body";
+const FILTER_ID = "reading-tasks-dashboard-filter";
+
+async function getAllItemTasks(): Promise<ItemTask[]> {
+	const tasks: ItemTask[] = [];
+	const libs = Zotero.Libraries.getAll();
+	for (const lib of libs) {
+		const items = await Zotero.Items.getAll(lib.libraryID, true);
+		for (const item of items) {
+			if (!item.isRegularItem()) {
+				continue;
+			}
+			for (const task of getReadingTasks(item)) {
+				tasks.push({ item, task });
+			}
+		}
+	}
+	return tasks;
+}
+
+function createRow(doc: Document, it: ItemTask) {
+	const row = doc.createElement("tr");
+	const cells = [
+		it.item.getField("title"),
+		it.task.module,
+		it.task.unit,
+		it.task.chapter || "",
+		it.task.pages || "",
+		it.task.paragraph || "",
+		it.task.type || "",
+		it.task.status,
+	];
+	for (const val of cells) {
+		const td = doc.createElement("td");
+		td.textContent = val;
+		row.appendChild(td);
+	}
+	return row;
+}
+
+export function open() {
+	const dialog = new DialogHelper(1, 1);
+	dialog.addCell(0, 0, {
+		tag: "vbox",
+		children: [
+			{
+				tag: "input",
+				namespace: "html",
+				attributes: {
+					id: FILTER_ID,
+					placeholder: getString("filter-placeholder"),
+					type: "search",
+				},
+			},
+			{
+				tag: "table",
+				namespace: "html",
+				children: [
+					{
+						tag: "thead",
+						children: [
+							{
+								tag: "tr",
+								children: [
+									{
+										tag: "th",
+										properties: { innerHTML: "Title" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Module" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Unit" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Chapter" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Pages" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Paragraph" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Type" },
+									},
+									{
+										tag: "th",
+										properties: { innerHTML: "Status" },
+									},
+								],
+							},
+						],
+					},
+					{ tag: "tbody", attributes: { id: BODY_ID } },
+				],
+			},
+		],
+	});
+	dialog.addButton("Close", "close");
+	dialog.setDialogData({
+		loadCallback: () => {
+			void onLoad(dialog.window);
+		},
+		l10nFiles: "__addonRef__-addon.ftl",
+	});
+	dialog.open(getString("reading-tasks-dashboard-title"), {
+		width: 800,
+		height: 600,
+		resizable: true,
+	});
+}
+
+let currentTasks: ItemTask[] = [];
+let sortKey: keyof ItemTask["task"] | "title" = "title";
+let sortAsc = true;
+
+function applyFilterAndSort(doc: Document) {
+	const filter =
+		(
+			doc.getElementById(FILTER_ID) as HTMLInputElement | null
+		)?.value.toLowerCase() || "";
+	const tbody = doc.getElementById(BODY_ID) as HTMLTableSectionElement | null;
+	if (!tbody) {
+		return;
+	}
+	tbody.replaceChildren();
+	let tasks = currentTasks;
+	if (filter) {
+		tasks = tasks.filter((it) =>
+			`${it.item.getField("title")} ${it.task.module} ${it.task.unit} ${
+				it.task.chapter || ""
+			} ${it.task.pages || ""} ${it.task.paragraph || ""} ${
+				it.task.type || ""
+			} ${it.task.status}`
+				.toLowerCase()
+				.includes(filter),
+		);
+	}
+	tasks = tasks.slice().sort((a, b) => {
+		const va = getValue(a, sortKey);
+		const vb = getValue(b, sortKey);
+		if (va < vb) return sortAsc ? -1 : 1;
+		if (va > vb) return sortAsc ? 1 : -1;
+		return 0;
+	});
+	for (const it of tasks) {
+		tbody.appendChild(createRow(doc, it));
+	}
+}
+
+function getValue(it: ItemTask, key: keyof ItemTask["task"] | "title") {
+	if (key === "title") {
+		return it.item.getField("title");
+	}
+	return it.task[key] || "";
+}
+
+async function onLoad(win: Window) {
+	currentTasks = await getAllItemTasks();
+	const doc = win.document;
+	applyFilterAndSort(doc);
+	const filterInput = doc.getElementById(
+		FILTER_ID,
+	) as HTMLInputElement | null;
+	filterInput?.addEventListener("input", () => applyFilterAndSort(doc));
+	const headers = Array.from(doc.querySelectorAll("thead th"));
+	headers.forEach((th, index) => {
+		if (!th) {
+			return;
+		}
+		th.addEventListener("click", () => {
+			const keys = [
+				"title",
+				"module",
+				"unit",
+				"chapter",
+				"pages",
+				"paragraph",
+				"type",
+				"status",
+			] as (keyof ItemTask["task"] | "title")[];
+			const key = keys[index];
+			if (sortKey === key) {
+				sortAsc = !sortAsc;
+			} else {
+				sortKey = key;
+				sortAsc = true;
+			}
+			applyFilterAndSort(doc);
+		});
+	});
+}
+
+export default { open };

--- a/src/reading-tasks-dashboard.ts
+++ b/src/reading-tasks-dashboard.ts
@@ -15,7 +15,11 @@ async function getAllItemTasks(): Promise<ItemTask[]> {
 	const libs = Zotero.Libraries.getAll();
 	for (const lib of libs) {
 		const items = await Zotero.Items.getAll(lib.libraryID, true);
+		// Ensure each item is fully loaded so child notes are available
 		for (const item of items) {
+			if (typeof item.loadAllData === "function") {
+				await item.loadAllData();
+			}
 			if (!item.isRegularItem()) {
 				continue;
 			}

--- a/src/reading-tasks-dashboard.ts
+++ b/src/reading-tasks-dashboard.ts
@@ -42,6 +42,8 @@ function createRow(doc: Document, it: ItemTask) {
 	for (const val of cells) {
 		const td = doc.createElement("td");
 		td.textContent = val;
+		td.style.padding = "4px";
+		td.style.textAlign = "center";
 		row.appendChild(td);
 	}
 	return row;
@@ -53,17 +55,29 @@ export function open() {
 		tag: "vbox",
 		children: [
 			{
+				tag: "h2",
+				namespace: "html",
+				properties: {
+					innerHTML: getString("reading-tasks-dashboard-title"),
+					style: "text-align:center;margin:0 0 8px 0;",
+				},
+			},
+			{
 				tag: "input",
 				namespace: "html",
 				attributes: {
 					id: FILTER_ID,
 					placeholder: getString("filter-placeholder"),
 					type: "search",
+					style: "display:block;margin:0 auto 8px auto;width:95%;",
 				},
 			},
 			{
 				tag: "table",
 				namespace: "html",
+				attributes: {
+					style: "width:100%;border-collapse:collapse;text-align:center;",
+				},
 				children: [
 					{
 						tag: "thead",
@@ -73,35 +87,59 @@ export function open() {
 								children: [
 									{
 										tag: "th",
-										properties: { innerHTML: "Title" },
+										properties: {
+											innerHTML: "Title",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Module" },
+										properties: {
+											innerHTML: "Module",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Unit" },
+										properties: {
+											innerHTML: "Unit",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Chapter" },
+										properties: {
+											innerHTML: "Chapter",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Pages" },
+										properties: {
+											innerHTML: "Pages",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Paragraph" },
+										properties: {
+											innerHTML: "Paragraph",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Type" },
+										properties: {
+											innerHTML: "Type",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Status" },
+										properties: {
+											innerHTML: "Status",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 								],
 							},

--- a/src/reading-tasks-import.ts
+++ b/src/reading-tasks-import.ts
@@ -1,145 +1,80 @@
 import { DialogHelper } from "zotero-plugin-toolkit";
 import { getString } from "./utils/locale";
-import { ReadingTask, setReadingTasks } from "./modules/reading-tasks";
-import { updateItemTagsFromTasks } from "./modules/reading-tasks";
-
-interface ImportEntry {
-	title: string;
-	tasks: ReadingTask[];
-}
-
-interface ItemMap {
-	[title: string]: Zotero.Item[];
-}
+import {
+	ReadingTask,
+	setReadingTasks,
+	updateItemTagsFromTasks,
+	sortTasks,
+} from "./modules/reading-tasks";
 
 const INPUT_ID = "import-reading-tasks-input";
 const TABLE_BODY = "import-reading-tasks-table";
-const TITLE_LIST = "import-reading-tasks-title-list";
+let currentItem: Zotero.Item | null = null;
+let parsedTasks: ReadingTask[] = [];
 
-let itemsByTitle: ItemMap = {};
-let parsedEntries: ImportEntry[] = [];
-
-function parseText(text: string): ImportEntry[] {
-	const blocks = text
-		.split(/\n\s*\n/)
-		.map((b) => b.trim())
-		.filter(Boolean);
-	const entries: ImportEntry[] = [];
-	for (const block of blocks) {
-		const m = block.match(/^(.*)\nReading_Tasks:([\s\S]+)$/);
-		if (!m) {
-			continue;
-		}
-		const title = m[1].trim();
-		const json = m[2].trim();
-		try {
-			const tasks = JSON.parse(json) as ReadingTask[];
-			entries.push({ title, tasks });
-		} catch {
-			// ignore malformed JSON
-		}
-	}
-	return entries;
-}
-
-async function gatherItems() {
-	itemsByTitle = {};
-	const libs = Zotero.Libraries.getAll();
-	for (const lib of libs) {
-		const items = await Zotero.Items.getAll(lib.libraryID, true);
-		for (const item of items) {
-			if (!item.isRegularItem()) continue;
-			if (typeof item.loadAllData === "function") {
-				await item.loadAllData();
-			}
-			const t = item.getField("title");
-			if (!t) continue;
-			const key = t.toLowerCase();
-			if (!itemsByTitle[key]) itemsByTitle[key] = [];
-			itemsByTitle[key].push(item);
-		}
+function parseTasks(text: string): ReadingTask[] {
+	const trimmed = text.trim();
+	if (!trimmed) return [];
+	const m = trimmed.match(/Reading_Tasks:\s*([\s\S]+)/);
+	const jsonText = m ? m[1].trim() : trimmed;
+	try {
+		return JSON.parse(jsonText) as ReadingTask[];
+	} catch {
+		return [];
 	}
 }
 
-function fillDatalist(doc: Document) {
-	const list = doc.getElementById(TITLE_LIST) as HTMLDataListElement | null;
-	if (!list) return;
-	list.replaceChildren();
-	for (const titleKey of Object.keys(itemsByTitle)) {
-		const item = itemsByTitle[titleKey][0];
-		const opt = doc.createElement("option");
-		opt.value = item.getField("title") || "";
-		list.appendChild(opt);
-	}
-}
-
-function createRow(doc: Document, entry: ImportEntry, index: number) {
+function createRow(doc: Document, task: ReadingTask) {
 	const tr = doc.createElement("tr");
-	tr.dataset.index = String(index);
-
-	const titleTd = doc.createElement("td");
-	titleTd.textContent = entry.title;
-	titleTd.style.padding = "4px";
-	titleTd.style.textAlign = "center";
-
-	const matchTd = doc.createElement("td");
-	const input = doc.createElement("input");
-	input.setAttribute("list", TITLE_LIST);
-	const match = (itemsByTitle[entry.title.toLowerCase()] || [])[0];
-	if (match) {
-		input.value = match.getField("title") || "";
+	const vals = [
+		task.module,
+		task.unit,
+		task.chapter || "",
+		task.pages || "",
+		task.paragraph || "",
+		task.type || "",
+		task.status,
+	];
+	for (const val of vals) {
+		const td = doc.createElement("td");
+		td.textContent = val;
+		td.style.padding = "4px";
+		td.style.textAlign = "center";
+		tr.appendChild(td);
 	}
-	matchTd.appendChild(input);
-	matchTd.style.padding = "4px";
-	matchTd.style.textAlign = "center";
-
-	tr.appendChild(titleTd);
-	tr.appendChild(matchTd);
 	return tr;
 }
 
-function parse(window: Window) {
-	const textarea = window.document.getElementById(
+function parse(win: Window) {
+	const textarea = win.document.getElementById(
 		INPUT_ID,
 	) as HTMLTextAreaElement | null;
 	if (!textarea) return;
-	parsedEntries = parseText(textarea.value);
-	const tbody = window.document.getElementById(
+	parsedTasks = sortTasks(parseTasks(textarea.value));
+	const tbody = win.document.getElementById(
 		TABLE_BODY,
 	) as HTMLTableSectionElement | null;
 	if (!tbody) return;
 	tbody.replaceChildren();
-	parsedEntries.forEach((e, idx) => {
-		tbody.appendChild(createRow(window.document, e, idx));
-	});
-}
-
-function doImport(window: Window) {
-	const tbody = window.document.getElementById(
-		TABLE_BODY,
-	) as HTMLTableSectionElement | null;
-	if (!tbody) return;
-	const rows = Array.from(tbody.children) as HTMLTableRowElement[];
-	for (const row of rows) {
-		const idx = Number(row.dataset.index);
-		const entry = parsedEntries[idx];
-		const input = row.querySelector<HTMLInputElement>("input");
-		if (!input) continue;
-		const title = input.value.trim().toLowerCase();
-		const item = itemsByTitle[title]?.[0];
-		if (!item) continue;
-		setReadingTasks(item, entry.tasks);
-		updateItemTagsFromTasks(item);
+	for (const t of parsedTasks) {
+		tbody.appendChild(createRow(win.document, t));
 	}
-	window.close();
 }
 
-async function onLoad(win: Window) {
-	await gatherItems();
-	fillDatalist(win.document);
+function doImport(win: Window) {
+	if (!currentItem) return;
+	setReadingTasks(currentItem, parsedTasks);
+	updateItemTagsFromTasks(currentItem);
+	win.close();
 }
 
-export function open() {
+function onLoad(win: Window) {
+	// nothing to load
+}
+
+export function open(item: Zotero.Item) {
+	currentItem = item;
+	parsedTasks = [];
 	const dialog = new DialogHelper(1, 1);
 	dialog.addCell(0, 0, {
 		tag: "vbox",
@@ -153,17 +88,20 @@ export function open() {
 				},
 			},
 			{
+				tag: "div",
+				namespace: "html",
+				properties: {
+					innerHTML: item.getField("title") || "",
+					style: "text-align:center;font-weight:bold;margin-bottom:8px;",
+				},
+			},
+			{
 				tag: "textarea",
 				namespace: "html",
 				attributes: {
 					id: INPUT_ID,
 					style: "width:95%;height:120px;display:block;margin:0 auto 8px auto;",
 				},
-			},
-			{
-				tag: "datalist",
-				namespace: "html",
-				attributes: { id: TITLE_LIST },
 			},
 			{
 				tag: "table",
@@ -181,14 +119,49 @@ export function open() {
 									{
 										tag: "th",
 										properties: {
-											innerHTML: "Import Title",
+											innerHTML: "Module",
 											style: "padding:4px;text-align:center;",
 										},
 									},
 									{
 										tag: "th",
 										properties: {
-											innerHTML: "Matched Item",
+											innerHTML: "Unit",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Chapter",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Pages",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Paragraph",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Type",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Status",
 											style: "padding:4px;text-align:center;",
 										},
 									},
@@ -210,7 +183,7 @@ export function open() {
 	});
 	dialog.addButton("Close", "cancel");
 	dialog.setDialogData({
-		loadCallback: () => void onLoad(dialog.window),
+		loadCallback: () => onLoad(dialog.window),
 		l10nFiles: "__addonRef__-addon.ftl",
 	});
 	dialog.open(getString("import-reading-tasks-title"), {

--- a/src/reading-tasks-import.ts
+++ b/src/reading-tasks-import.ts
@@ -1,0 +1,223 @@
+import { DialogHelper } from "zotero-plugin-toolkit";
+import { getString } from "./utils/locale";
+import { ReadingTask, setReadingTasks } from "./modules/reading-tasks";
+import { updateItemTagsFromTasks } from "./modules/reading-tasks";
+
+interface ImportEntry {
+	title: string;
+	tasks: ReadingTask[];
+}
+
+interface ItemMap {
+	[title: string]: Zotero.Item[];
+}
+
+const INPUT_ID = "import-reading-tasks-input";
+const TABLE_BODY = "import-reading-tasks-table";
+const TITLE_LIST = "import-reading-tasks-title-list";
+
+let itemsByTitle: ItemMap = {};
+let parsedEntries: ImportEntry[] = [];
+
+function parseText(text: string): ImportEntry[] {
+	const blocks = text
+		.split(/\n\s*\n/)
+		.map((b) => b.trim())
+		.filter(Boolean);
+	const entries: ImportEntry[] = [];
+	for (const block of blocks) {
+		const m = block.match(/^(.*)\nReading_Tasks:([\s\S]+)$/);
+		if (!m) {
+			continue;
+		}
+		const title = m[1].trim();
+		const json = m[2].trim();
+		try {
+			const tasks = JSON.parse(json) as ReadingTask[];
+			entries.push({ title, tasks });
+		} catch {
+			// ignore malformed JSON
+		}
+	}
+	return entries;
+}
+
+async function gatherItems() {
+	itemsByTitle = {};
+	const libs = Zotero.Libraries.getAll();
+	for (const lib of libs) {
+		const items = await Zotero.Items.getAll(lib.libraryID, true);
+		for (const item of items) {
+			if (!item.isRegularItem()) continue;
+			if (typeof item.loadAllData === "function") {
+				await item.loadAllData();
+			}
+			const t = item.getField("title");
+			if (!t) continue;
+			const key = t.toLowerCase();
+			if (!itemsByTitle[key]) itemsByTitle[key] = [];
+			itemsByTitle[key].push(item);
+		}
+	}
+}
+
+function fillDatalist(doc: Document) {
+	const list = doc.getElementById(TITLE_LIST) as HTMLDataListElement | null;
+	if (!list) return;
+	list.replaceChildren();
+	for (const titleKey of Object.keys(itemsByTitle)) {
+		const item = itemsByTitle[titleKey][0];
+		const opt = doc.createElement("option");
+		opt.value = item.getField("title") || "";
+		list.appendChild(opt);
+	}
+}
+
+function createRow(doc: Document, entry: ImportEntry, index: number) {
+	const tr = doc.createElement("tr");
+	tr.dataset.index = String(index);
+
+	const titleTd = doc.createElement("td");
+	titleTd.textContent = entry.title;
+	titleTd.style.padding = "4px";
+	titleTd.style.textAlign = "center";
+
+	const matchTd = doc.createElement("td");
+	const input = doc.createElement("input");
+	input.setAttribute("list", TITLE_LIST);
+	const match = (itemsByTitle[entry.title.toLowerCase()] || [])[0];
+	if (match) {
+		input.value = match.getField("title") || "";
+	}
+	matchTd.appendChild(input);
+	matchTd.style.padding = "4px";
+	matchTd.style.textAlign = "center";
+
+	tr.appendChild(titleTd);
+	tr.appendChild(matchTd);
+	return tr;
+}
+
+function parse(window: Window) {
+	const textarea = window.document.getElementById(
+		INPUT_ID,
+	) as HTMLTextAreaElement | null;
+	if (!textarea) return;
+	parsedEntries = parseText(textarea.value);
+	const tbody = window.document.getElementById(
+		TABLE_BODY,
+	) as HTMLTableSectionElement | null;
+	if (!tbody) return;
+	tbody.replaceChildren();
+	parsedEntries.forEach((e, idx) => {
+		tbody.appendChild(createRow(window.document, e, idx));
+	});
+}
+
+function doImport(window: Window) {
+	const tbody = window.document.getElementById(
+		TABLE_BODY,
+	) as HTMLTableSectionElement | null;
+	if (!tbody) return;
+	const rows = Array.from(tbody.children) as HTMLTableRowElement[];
+	for (const row of rows) {
+		const idx = Number(row.dataset.index);
+		const entry = parsedEntries[idx];
+		const input = row.querySelector<HTMLInputElement>("input");
+		if (!input) continue;
+		const title = input.value.trim().toLowerCase();
+		const item = itemsByTitle[title]?.[0];
+		if (!item) continue;
+		setReadingTasks(item, entry.tasks);
+		updateItemTagsFromTasks(item);
+	}
+	window.close();
+}
+
+async function onLoad(win: Window) {
+	await gatherItems();
+	fillDatalist(win.document);
+}
+
+export function open() {
+	const dialog = new DialogHelper(1, 1);
+	dialog.addCell(0, 0, {
+		tag: "vbox",
+		children: [
+			{
+				tag: "h2",
+				namespace: "html",
+				properties: {
+					innerHTML: getString("import-reading-tasks-title"),
+					style: "text-align:center;margin:0 0 8px 0;",
+				},
+			},
+			{
+				tag: "textarea",
+				namespace: "html",
+				attributes: {
+					id: INPUT_ID,
+					style: "width:95%;height:120px;display:block;margin:0 auto 8px auto;",
+				},
+			},
+			{
+				tag: "datalist",
+				namespace: "html",
+				attributes: { id: TITLE_LIST },
+			},
+			{
+				tag: "table",
+				namespace: "html",
+				attributes: {
+					style: "width:100%;border-collapse:collapse;text-align:center;",
+				},
+				children: [
+					{
+						tag: "thead",
+						children: [
+							{
+								tag: "tr",
+								children: [
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Import Title",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+									{
+										tag: "th",
+										properties: {
+											innerHTML: "Matched Item",
+											style: "padding:4px;text-align:center;",
+										},
+									},
+								],
+							},
+						],
+					},
+					{ tag: "tbody", attributes: { id: TABLE_BODY } },
+				],
+			},
+		],
+	});
+	dialog.addButton(getString("import-reading-tasks-parse"), "parse", {
+		noClose: true,
+		callback: () => parse(dialog.window),
+	});
+	dialog.addButton(getString("import-reading-tasks-import"), "import", {
+		callback: () => void doImport(dialog.window),
+	});
+	dialog.addButton("Close", "cancel");
+	dialog.setDialogData({
+		loadCallback: () => void onLoad(dialog.window),
+		l10nFiles: "__addonRef__-addon.ftl",
+	});
+	dialog.open(getString("import-reading-tasks-title"), {
+		width: 600,
+		height: 500,
+		resizable: true,
+	});
+}
+
+export default { open };

--- a/src/reading-tasks-import.ts
+++ b/src/reading-tasks-import.ts
@@ -72,9 +72,12 @@ function onLoad(win: Window) {
 	// nothing to load
 }
 
-export function open(item: Zotero.Item) {
+export async function open(item: Zotero.Item) {
 	currentItem = item;
 	parsedTasks = [];
+	if (typeof item.loadAllData === "function") {
+		await item.loadAllData();
+	}
 	const dialog = new DialogHelper(1, 1);
 	dialog.addCell(0, 0, {
 		tag: "vbox",

--- a/src/reading-tasks-view.ts
+++ b/src/reading-tasks-view.ts
@@ -91,6 +91,8 @@ function createTableRow(dialog: DialogHelper, task: Partial<ReadingTask> = {}) {
 	const typeGroup = dialog.createElement(doc, "div", {
 		namespace: "html",
 	});
+	typeGroup.style.display = "flex";
+	typeGroup.style.justifyContent = "center";
 	const typeNames = [
 		getString("reading-task-type-required"),
 		getString("reading-task-type-additional"),
@@ -119,6 +121,8 @@ function createTableRow(dialog: DialogHelper, task: Partial<ReadingTask> = {}) {
 		namespace: "html",
 	});
 	group.classList.add("status-group");
+	group.style.display = "flex";
+	group.style.justifyContent = "center";
 	// reuse rowIndex for status radios
 	statusNames.forEach((name, index) => {
 		const label = dialog.createElement(doc, "label", {
@@ -168,6 +172,19 @@ function createTableRow(dialog: DialogHelper, task: Partial<ReadingTask> = {}) {
 		statusCell,
 		removeCell,
 	);
+	for (const cell of [
+		moduleCell,
+		unitCell,
+		chapterCell,
+		pagesCell,
+		paragraphCell,
+		typeCell,
+		statusCell,
+		removeCell,
+	]) {
+		(cell as HTMLElement).style.padding = "4px";
+		(cell as HTMLElement).style.textAlign = "center";
+	}
 	return row;
 }
 
@@ -208,15 +225,25 @@ function save(window: Window) {
 	const tasks: ReadingTask[] = [];
 	for (const row of rows) {
 		const cells = row.children;
-		const typeInput = cells[5].querySelector('input[type="radio"]:checked') as HTMLInputElement | null;
-		const statusInput = cells[6].querySelector('input[type="radio"]:checked') as HTMLInputElement | null;
+		const typeInput = cells[5].querySelector<HTMLInputElement>(
+			'input[type="radio"]:checked',
+		);
+		const statusInput = cells[6].querySelector<HTMLInputElement>(
+			'input[type="radio"]:checked',
+		);
 
 		tasks.push({
 			module: (cells[0].firstChild as HTMLInputElement).value.trim(),
 			unit: (cells[1].firstChild as HTMLInputElement).value.trim(),
-			chapter: (cells[2].firstChild as HTMLInputElement).value.trim() || undefined,
-			pages: (cells[3].firstChild as HTMLInputElement).value.trim() || undefined,
-			paragraph: (cells[4].firstChild as HTMLInputElement).value.trim() || undefined,
+			chapter:
+				(cells[2].firstChild as HTMLInputElement).value.trim() ||
+				undefined,
+			pages:
+				(cells[3].firstChild as HTMLInputElement).value.trim() ||
+				undefined,
+			paragraph:
+				(cells[4].firstChild as HTMLInputElement).value.trim() ||
+				undefined,
 			type: typeInput?.value || undefined,
 			status: statusInput?.value || statusNames[0],
 		});
@@ -257,7 +284,18 @@ async function open(item: Zotero.Item) {
 			{
 				tag: "h2",
 				namespace: "html",
-				properties: { innerHTML: getString("reading-tasks-title") },
+				properties: {
+					innerHTML: getString("reading-tasks-title"),
+					style: "text-align:center;margin:0;",
+				},
+			},
+			{
+				tag: "div",
+				namespace: "html",
+				properties: {
+					innerHTML: item.getField("title"),
+					style: "text-align:center;font-weight:bold;margin-bottom:8px;",
+				},
 			},
 			{
 				tag: "datalist",
@@ -280,6 +318,9 @@ async function open(item: Zotero.Item) {
 			{
 				tag: "table",
 				namespace: "html",
+				attributes: {
+					style: "width:100%;border-collapse:collapse;text-align:center;",
+				},
 				children: [
 					{
 						tag: "thead",
@@ -289,35 +330,59 @@ async function open(item: Zotero.Item) {
 								children: [
 									{
 										tag: "th",
-										properties: { innerHTML: "Module" },
+										properties: {
+											innerHTML: "Module",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Unit" },
+										properties: {
+											innerHTML: "Unit",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Chapter" },
+										properties: {
+											innerHTML: "Chapter",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Pages" },
+										properties: {
+											innerHTML: "Pages",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Paragraph" },
+										properties: {
+											innerHTML: "Paragraph",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Type" },
+										properties: {
+											innerHTML: "Type",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Status" },
+										properties: {
+											innerHTML: "Status",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 									{
 										tag: "th",
-										properties: { innerHTML: "Remove" },
+										properties: {
+											innerHTML: "Remove",
+											style: "padding:4px;text-align:center;",
+										},
 									},
 								],
 							},

--- a/src/reading-tasks-view.ts
+++ b/src/reading-tasks-view.ts
@@ -13,6 +13,7 @@ import {
 import { setItemExtraProperty } from "./utils/extraField";
 import { DialogHelper } from "zotero-plugin-toolkit";
 import { getString } from "./utils/locale";
+import { getTitleFromNote } from "./utils/noteHelpers";
 
 const TABLE_BODY = "reading-tasks-table-body";
 let rowsCounter = 0;
@@ -272,6 +273,9 @@ function onLoad(window: Window) {
 
 async function open(item: Zotero.Item) {
 	rowsCounter = 0;
+	if (typeof item.loadAllData === "function") {
+		await item.loadAllData();
+	}
 	const allTags = (await Zotero.Tags.getAll(item.libraryID)).map(
 		(t) => t.tag,
 	);
@@ -293,7 +297,8 @@ async function open(item: Zotero.Item) {
 				tag: "div",
 				namespace: "html",
 				properties: {
-					innerHTML: item.getField("title"),
+					innerHTML:
+						item.getField("title") || getTitleFromNote(item) || "",
 					style: "text-align:center;font-weight:bold;margin-bottom:8px;",
 				},
 			},

--- a/src/utils/noteHelpers.ts
+++ b/src/utils/noteHelpers.ts
@@ -1,10 +1,14 @@
-export const READING_LIST_NOTE_TITLE = "ReadingListTasks";
+export const READING_LIST_NOTE_MARKER = "ReadingListTasks";
 
 export function findReadingTasksNote(item: Zotero.Item): Zotero.Item | null {
 	const noteIDs = item.getNotes();
 	for (const id of noteIDs) {
 		const note = Zotero.Items.get(id);
-		if (note && note.getField("title") === READING_LIST_NOTE_TITLE) {
+		if (!note?.isNote()) {
+			continue;
+		}
+		const content = note.getNote();
+		if (content.startsWith(READING_LIST_NOTE_MARKER)) {
 			return note;
 		}
 	}
@@ -19,21 +23,24 @@ export function getOrCreateReadingTasksNote(item: Zotero.Item): Zotero.Item {
 	const note = new Zotero.Item("note");
 	note.libraryID = item.libraryID;
 	note.parentID = item.id;
-	note.setField("title", READING_LIST_NOTE_TITLE);
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	(note as any).hidden = true;
-	note.setNote("[]");
+	note.setNote(`${READING_LIST_NOTE_MARKER}\n[]`);
 	void note.saveTx();
 	return note;
 }
 
 export function getTasksFromNote(item: Zotero.Item): string | null {
 	const note = findReadingTasksNote(item);
-	return note ? note.getNote() : null;
+	if (!note) {
+		return null;
+	}
+	const content = note.getNote();
+	return content.replace(/^.+?\n/, "");
 }
 
 export function saveTasksToNote(item: Zotero.Item, tasks: string): void {
 	const note = getOrCreateReadingTasksNote(item);
-	note.setNote(tasks);
+	note.setNote(`${READING_LIST_NOTE_MARKER}\n${tasks}`);
 	void note.saveTx();
 }

--- a/src/utils/noteHelpers.ts
+++ b/src/utils/noteHelpers.ts
@@ -54,7 +54,7 @@ export function getOrCreateReadingTasksNote(item: Zotero.Item): Zotero.Item {
 	note.parentID = item.id;
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	(note as any).hidden = true;
-	const title = item.getField("title");
+	const title = item.getField("title") || "";
 	note.setNote(encodeContent(title, "[]"));
 	void note.saveTx();
 	return note;
@@ -65,7 +65,14 @@ export function getTasksFromNote(item: Zotero.Item): string | null {
 	if (!note) {
 		return null;
 	}
-	const { tasks } = decodeContent(note.getNote());
+	const { title, tasks } = decodeContent(note.getNote());
+	if (!title) {
+		const itemTitle = item.getField("title");
+		if (itemTitle) {
+			note.setNote(encodeContent(itemTitle, tasks));
+			void note.saveTx();
+		}
+	}
 	return tasks;
 }
 
@@ -74,13 +81,21 @@ export function getTitleFromNote(item: Zotero.Item): string | null {
 	if (!note) {
 		return null;
 	}
-	const { title } = decodeContent(note.getNote());
+	const { title, tasks } = decodeContent(note.getNote());
+	if (!title) {
+		const itemTitle = item.getField("title");
+		if (itemTitle) {
+			note.setNote(encodeContent(itemTitle, tasks));
+			void note.saveTx();
+			return itemTitle;
+		}
+	}
 	return title;
 }
 
 export function saveTasksToNote(item: Zotero.Item, tasks: string): void {
 	const note = getOrCreateReadingTasksNote(item);
-	const title = item.getField("title");
+	const title = item.getField("title") || getTitleFromNote(item) || "";
 	note.setNote(encodeContent(title, tasks));
 	void note.saveTx();
 }

--- a/src/utils/noteHelpers.ts
+++ b/src/utils/noteHelpers.ts
@@ -1,6 +1,17 @@
 export const READING_LIST_NOTE_MARKER = "ReadingListTasks";
 const TITLE_SEP = ":";
 
+function getItemTitle(item: Zotero.Item): string {
+	const fields = ["title", "caseName", "nameOfAct", "shortTitle"];
+	for (const field of fields) {
+		const val = item.getField(field as any);
+		if (val) {
+			return val;
+		}
+	}
+	return "";
+}
+
 function encodeContent(title: string, tasks: string): string {
 	return `${READING_LIST_NOTE_MARKER}${TITLE_SEP}${title}\n${tasks}`;
 }
@@ -54,7 +65,7 @@ export function getOrCreateReadingTasksNote(item: Zotero.Item): Zotero.Item {
 	note.parentID = item.id;
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	(note as any).hidden = true;
-	const title = item.getField("title") || "";
+	const title = getItemTitle(item);
 	note.setNote(encodeContent(title, "[]"));
 	void note.saveTx();
 	return note;
@@ -67,7 +78,7 @@ export function getTasksFromNote(item: Zotero.Item): string | null {
 	}
 	const { title, tasks } = decodeContent(note.getNote());
 	if (!title) {
-		const itemTitle = item.getField("title");
+		const itemTitle = getItemTitle(item);
 		if (itemTitle) {
 			note.setNote(encodeContent(itemTitle, tasks));
 			void note.saveTx();
@@ -83,7 +94,7 @@ export function getTitleFromNote(item: Zotero.Item): string | null {
 	}
 	const { title, tasks } = decodeContent(note.getNote());
 	if (!title) {
-		const itemTitle = item.getField("title");
+		const itemTitle = getItemTitle(item);
 		if (itemTitle) {
 			note.setNote(encodeContent(itemTitle, tasks));
 			void note.saveTx();
@@ -95,7 +106,7 @@ export function getTitleFromNote(item: Zotero.Item): string | null {
 
 export function saveTasksToNote(item: Zotero.Item, tasks: string): void {
 	const note = getOrCreateReadingTasksNote(item);
-	const title = item.getField("title") || getTitleFromNote(item) || "";
+	const title = getItemTitle(item) || getTitleFromNote(item) || "";
 	note.setNote(encodeContent(title, tasks));
 	void note.saveTx();
 }

--- a/src/utils/noteHelpers.ts
+++ b/src/utils/noteHelpers.ts
@@ -1,0 +1,39 @@
+export const READING_LIST_NOTE_TITLE = "ReadingListTasks";
+
+export function findReadingTasksNote(item: Zotero.Item): Zotero.Item | null {
+	const noteIDs = item.getNotes();
+	for (const id of noteIDs) {
+		const note = Zotero.Items.get(id);
+		if (note && note.getField("title") === READING_LIST_NOTE_TITLE) {
+			return note;
+		}
+	}
+	return null;
+}
+
+export function getOrCreateReadingTasksNote(item: Zotero.Item): Zotero.Item {
+	const existing = findReadingTasksNote(item);
+	if (existing) {
+		return existing;
+	}
+	const note = new Zotero.Item("note");
+	note.libraryID = item.libraryID;
+	note.parentID = item.id;
+	note.setField("title", READING_LIST_NOTE_TITLE);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	(note as any).hidden = true;
+	note.setNote("[]");
+	void note.saveTx();
+	return note;
+}
+
+export function getTasksFromNote(item: Zotero.Item): string | null {
+	const note = findReadingTasksNote(item);
+	return note ? note.getNote() : null;
+}
+
+export function saveTasksToNote(item: Zotero.Item, tasks: string): void {
+	const note = getOrCreateReadingTasksNote(item);
+	note.setNote(tasks);
+	void note.saveTx();
+}


### PR DESCRIPTION
## Summary
- add helper to find or create hidden "ReadingListTasks" note
- store reading tasks JSON in that note instead of the Extra field

## Testing
- `npx tsc --noEmit`
- `npx prettier -w src/utils/noteHelpers.ts src/modules/reading-tasks.ts`
- `npx eslint src/modules/reading-tasks.ts src/utils/noteHelpers.ts`


------
https://chatgpt.com/codex/tasks/task_e_684c25ef976c8332bb6746e5577cc1d1